### PR TITLE
fix: Prevent strings from being converted to booleans in to_yaml

### DIFF
--- a/src/ivcap_sdk_service/service.py
+++ b/src/ivcap_sdk_service/service.py
@@ -163,7 +163,9 @@ class Service(JSONWizard):
         return d
 
     def to_yaml(self) -> str:
-        return yaml.dump(self.to_dict(), default_flow_style=False)
+        as_dict = self.to_dict()
+        as_yaml = yaml.dump(as_dict, default_flow_style=False, default_style='"')
+        return as_yaml
 
     def append_arguments(self, ap: ArgumentParser) -> ArgumentParser:
         type2type = {


### PR DESCRIPTION
This change aims to fix #8 